### PR TITLE
[# 130775889] As a patient, so my eligibility is up to date and accurate, implement the "provenance" state in DynamoDB 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    dynasore (0.1.0)
+    dynasore (0.1.1)
       aws-record
       aws-sdk (~> 2)
       rails

--- a/lib/dynasore.rb
+++ b/lib/dynasore.rb
@@ -2,6 +2,7 @@ require 'active_support/core_ext/module/delegation.rb'
 
 require 'dynasore/binary_attribute.rb'
 require 'dynasore/binary_string.rb'
+require 'dynasore/cast.rb'
 require 'dynasore/configuration.rb'
 require 'dynasore/version.rb'
 

--- a/lib/dynasore/cast.rb
+++ b/lib/dynasore/cast.rb
@@ -1,0 +1,11 @@
+module Dynasore
+  module Cast
+    def self.time(ruby_time)
+      Aws::Record::Marshalers::DateTimeMarshaler.new.serialize(ruby_time)
+    end
+
+    def self.integer(string_or_int)
+      Integer(string_or_int)
+    end
+  end
+end

--- a/lib/dynasore/version.rb
+++ b/lib/dynasore/version.rb
@@ -1,3 +1,3 @@
 module Dynasore
-  VERSION = '0.1.0'.freeze
+  VERSION = '0.1.1'.freeze
 end

--- a/spec/lib/dynasore/cast_spec.rb
+++ b/spec/lib/dynasore/cast_spec.rb
@@ -1,0 +1,17 @@
+
+describe Dynasore::Cast do
+  describe '.time' do
+    it 'converts a Time to a UTC string in Dynamo format' do
+      time = 3.hours.ago
+      expect(Dynasore::Cast.time("#{time}")).to eq(Aws::Record::Marshalers::DateTimeMarshaler.new.serialize(time))
+    end
+  end
+
+  describe '.integer' do
+    let(:random){ SecureRandom.random_number(10_000_000_000) }
+
+    it 'converts a string as returned from Dynamo into an int for its queries' do
+      expect(Dynasore::Cast.integer("#{random}")).to eq(random)
+    end
+  end
+end


### PR DESCRIPTION
Needed to add some easy typecasts, because the aws::record gem doesn't do them for us in query conditions.  It might be good to experiment with a different library; dynamoid is clearly easier to use, but much much heavier. Splitting `anna` out would be a good opportunity for that. Ah well.

This has to be merged before https://github.com/ConsultingMD/stone/pull/215 can be; its Gemfile will be need to be updated once hthis is merged.

[Tracker #130775889](https://www.pivotaltracker.com/story/show/130775889)